### PR TITLE
fix: task-excutor logs will no longer be prefixed with golem-js

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ const executor = await TaskExecutor.create({
 
 ## Debugging
 
-The library uses the [debug](https://www.npmjs.com/package/debug) package to provide debug logs. To enable them, set the `DEBUG` environment variable to `golem-js:*` or `golem-js:market:*` to see all logs or only the market-related ones, respectively. For more information, please refer to the [debug package documentation](https://www.npmjs.com/package/debug).
+The library uses the [debug](https://www.npmjs.com/package/debug) package to provide debug logs. To enable them, set the `DEBUG` environment variable to `task-executor:*` to see the related log lines. For more information, please refer to the [debug package documentation](https://www.npmjs.com/package/debug).
 
 ## Testing
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "LGPL-3.0",
       "dependencies": {
-        "@golem-sdk/golem-js": "^2.0.0",
+        "@golem-sdk/golem-js": "^2.1.0",
         "eventemitter3": "^5.0.1"
       },
       "devDependencies": {
@@ -1533,9 +1533,9 @@
       "dev": true
     },
     "node_modules/@golem-sdk/golem-js": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@golem-sdk/golem-js/-/golem-js-2.0.0.tgz",
-      "integrity": "sha512-jv9Ny2EHx7Qsb06rb9JE76+T2qux1wirfNhQ9a4vPwN+UPcieB96wVhQC/8Va+reJO0sRCaw82nBPscWhkADJQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@golem-sdk/golem-js/-/golem-js-2.1.0.tgz",
+      "integrity": "sha512-eXwxs7hx3cEp4y/U91iVOM/8uCChYyIaU9sQrly1L4B0yRdsD6xMNaLMpFt90zA9ij7DKpyxewiIm9wuMGc/6Q==",
       "dependencies": {
         "async-lock": "^1.4.0",
         "axios": "^1.6.2",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "node": ">=18.0.0"
   },
   "dependencies": {
-    "@golem-sdk/golem-js": "^2.0.0",
+    "@golem-sdk/golem-js": "^2.1.0",
     "eventemitter3": "^5.0.1"
   },
   "devDependencies": {

--- a/src/config.ts
+++ b/src/config.ts
@@ -93,7 +93,7 @@ export class ExecutorConfig {
       const isLoggingEnabled = options.enableLogging ?? DEFAULTS.enableLogging;
       if (!isLoggingEnabled) return nullLogger();
       if (options.logger) return options.logger.child("task-executor");
-      return defaultLogger("task-executor");
+      return defaultLogger("task-executor", { disableAutoPrefix: true });
     })();
     this.eventTarget = options.eventTarget || new EventTarget();
     this.maxTaskRetries = options.maxTaskRetries ?? DEFAULTS.maxTaskRetries;
@@ -127,7 +127,7 @@ export class TaskConfig extends ActivityConfig {
     this.taskTimeout = options?.taskTimeout || DEFAULTS.taskTimeout;
     this.activityStateCheckingInterval =
       options?.activityStateCheckingInterval || DEFAULTS.activityStateCheckingInterval;
-    this.logger = options?.logger || defaultLogger("work");
+    this.logger = options?.logger || defaultLogger("work", { disableAutoPrefix: true });
     this.storageProvider = options?.storageProvider;
     this.activityPreparingTimeout = options?.activityPreparingTimeout || DEFAULTS.activityPreparingTimeout;
   }


### PR DESCRIPTION
NOTE: This requires https://github.com/golemfactory/golem-js/pull/815 to be merged and released first!